### PR TITLE
Add "Premium edition" label

### DIFF
--- a/labels.json
+++ b/labels.json
@@ -273,5 +273,10 @@
     "name": "Bounty 💰",
     "color": "E6B800",
     "description": "Task with a reward for successful completion (paid after PR is merged)"
+  },
+  {
+    "name": "Premium edition",
+    "color": "4B2E83",
+    "description": "Feature or issue related to the premium version of the market-making bot with advanced functionality"
   }
 ]


### PR DESCRIPTION
## Description

Added "Premium edition" label — Feature or issue related to the premium version of the market-making bot with advanced functionality.

Color #4B2E83.

## Breaking changes

No.

## How to test

New label "Premium edition" appears across ADAMANT repos after the PR is merged.
