### PR TITLE
Add payment and tradebot-webui repos to label sync

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -30,6 +30,7 @@ jobs:
           "Adamant-im/adamant-im"
           "Adamant-im/.github"
           "Adamant-im/adamant-tradebot"
+          "Adamant-im/adamant-tradebot-webui"
           "Adamant-im/adamant"
           "Adamant-im/adamant-iOS"
           "Adamant-im/docs"
@@ -60,6 +61,8 @@ jobs:
           "Adamant-im/adamant-bountybot"
           "Adamant-im/adamant-tradebot-dex"
           "Adamant-im/adamant-notificationService"
+          "Adamant-im/adamant-payment"
+          "Adamant-im/adamant-payment-website"
           "Adamant-im/adamant-mixer"
           "Adamant-im/adamant-watchbot"
           )


### PR DESCRIPTION
## Summary

- Add `Adamant-im/adamant-payment`, `Adamant-im/adamant-payment-website`, and `Adamant-im/adamant-tradebot-webui` to the `Sync labels` workflow `REPOS` list
- These repos were missing from org label sync and only had GitHub default labels (or a partial manual set)

## Test plan

- [ ] Merge PR
- [ ] Run **Sync labels** workflow manually (`workflow_dispatch`) or push a no-op change to `labels.json`
- [ ] Verify all three repos have the full org label set (~57 labels)

Made with [Cursor](https://cursor.com)