### PR TITLE
Fix label sync: keep repo-specific labels

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -69,5 +69,5 @@ jobs:
                     
           for repo in "${REPOS[@]}"; do
             echo "Syncing $repo"
-            github-label-sync --access-token $LABELS_SYNC_TOKEN --labels labels.json $repo
+            github-label-sync --allow-added-labels --access-token $LABELS_SYNC_TOKEN --labels labels.json $repo
           done


### PR DESCRIPTION
## Problem

[Sync labels run #13](https://github.com/Adamant-im/.github/actions/runs/27501983785) failed on `Adamant-im/adamant-tradebot`:

```
> Added: the "dependencies" label in the repo is not expected. It will be deleted.
DELETE /repos/Adamant-im/adamant-tradebot/labels/dependencies
403: Resource not accessible by personal access token
```

`github-label-sync` tries to remove labels that are not in `labels.json`. The `dependencies` label (likely from Dependabot) is not in the org catalog, and `LABELS_SYNC_TOKEN` does not have permission to delete labels.

The workflow stopped before syncing the newly added repos (`adamant-payment`, `adamant-payment-website`, `adamant-tradebot-webui`).

## Fix

Pass `--allow-added-labels` so sync only creates/updates org labels and leaves extra repo labels (e.g. `dependencies`) untouched.

## Test plan

- [ ] Merge PR
- [ ] Re-run **Sync labels** workflow manually
- [ ] Confirm all repos complete successfully, including the three new payment/webui repos

Made with [Cursor](https://cursor.com)